### PR TITLE
Pull OTel version from the instrumentation BOM

### DIFF
--- a/opentelemetry-rxjava2-tracer/build.gradle.kts
+++ b/opentelemetry-rxjava2-tracer/build.gradle.kts
@@ -13,7 +13,6 @@ repositories {
 
 dependencies {
     api(platform("org.apache.logging.log4j:log4j-bom:2.19.0"))
-    api(platform("io.opentelemetry:opentelemetry-bom:1.21.0"))
     api(platform("io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:1.21.0-alpha"))
 
     api("io.opentelemetry:opentelemetry-api")

--- a/opentelemetry-rxjava3-tracer/build.gradle.kts
+++ b/opentelemetry-rxjava3-tracer/build.gradle.kts
@@ -13,7 +13,6 @@ repositories {
 
 dependencies {
     api(platform("org.apache.logging.log4j:log4j-bom:2.19.0"))
-    api(platform("io.opentelemetry:opentelemetry-bom:1.21.0"))
     api(platform("io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:1.21.0-alpha"))
 
     api("io.opentelemetry:opentelemetry-api")


### PR DESCRIPTION
OTel instrumentation BOM also pulls in the primary otel bom. Using only the instrumentation bom so the otel version is tied to one bom.